### PR TITLE
feat: git-hooksにブランチ保護機能を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,9 +126,32 @@ git-hooks: ## Git pre-commitフックをセットアップ
 	@echo "$(GREEN)🪝 Gitフックをセットアップ中...$(RESET)"
 	@mkdir -p .git/hooks
 	@echo '#!/bin/sh' > .git/hooks/pre-commit
+	@echo '' >> .git/hooks/pre-commit
+	@echo '# Branch protection check' >> .git/hooks/pre-commit
+	@echo 'current_branch=$$(git rev-parse --abbrev-ref HEAD)' >> .git/hooks/pre-commit
+	@echo 'protected_branches="main master develop"' >> .git/hooks/pre-commit
+	@echo '' >> .git/hooks/pre-commit
+	@echo 'for branch in $$protected_branches; do' >> .git/hooks/pre-commit
+	@echo '  if [ "$$current_branch" = "$$branch" ]; then' >> .git/hooks/pre-commit
+	@echo '    echo "🚨 Error: Direct commits to $$branch branch are not allowed!"' >> .git/hooks/pre-commit
+	@echo '    echo "Please create a feature branch instead:"' >> .git/hooks/pre-commit
+	@echo '    echo "  git checkout -b feat/your-feature-name"' >> .git/hooks/pre-commit
+	@echo '    exit 1' >> .git/hooks/pre-commit
+	@echo '  fi' >> .git/hooks/pre-commit
+	@echo 'done' >> .git/hooks/pre-commit
+	@echo '' >> .git/hooks/pre-commit
+	@echo '# Quality checks' >> .git/hooks/pre-commit
+	@echo 'echo "🔍 Running quality checks on branch: $$current_branch"' >> .git/hooks/pre-commit
 	@echo 'make quality' >> .git/hooks/pre-commit
+	@echo '' >> .git/hooks/pre-commit
+	@echo 'if [ $$? -eq 0 ]; then' >> .git/hooks/pre-commit
+	@echo '  echo "✅ All quality checks passed!"' >> .git/hooks/pre-commit
+	@echo 'else' >> .git/hooks/pre-commit
+	@echo '  echo "❌ Quality checks failed. Please fix issues before committing."' >> .git/hooks/pre-commit
+	@echo '  exit 1' >> .git/hooks/pre-commit
+	@echo 'fi' >> .git/hooks/pre-commit
 	@chmod +x .git/hooks/pre-commit
-	@echo "$(GREEN)✅ Pre-commitフックを設定しました$(RESET)"
+	@echo "$(GREEN)✅ Pre-commitフック（ブランチ保護付き）を設定しました$(RESET)"
 
 ## 📊 環境情報
 env-info: ## 開発環境の情報を表示


### PR DESCRIPTION
## Summary
- git-hooksターゲットにブランチ保護機能を追加
- main/master/developブランチへの直接コミットを防止し、適切なエラーメッセージを表示
- 品質チェック実行時の詳細なフィードバックと終了コード処理を改善

## Test plan
- [ ] `make git-hooks`を実行してpre-commitフックがセットアップされることを確認
- [ ] 保護されたブランチ（main/master/develop）で直接コミットを試行し、適切にブロックされることを確認
- [ ] フィーチャーブランチでコミット時に品質チェックが実行されることを確認
- [ ] 品質チェックが失敗した場合にコミットがブロックされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)