### PR TITLE
🚨 fix: 音声処理中のランタイムエラーを修正 (closes #26)

### DIFF
--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -529,9 +529,9 @@ function showSetupWizard(message = null) {
   
   // Add welcome message if provided
   if (message) {
-    const existingMessage = settingsModal.querySelector('.setup-message');
-    if (existingMessage) {
-      existingMessage.remove();
+    const setupMessageElement = settingsModal.querySelector('.setup-message');
+    if (setupMessageElement && setupMessageElement.remove) {
+      setupMessageElement.remove();
     }
     
     const messageDiv = document.createElement('div');
@@ -541,9 +541,9 @@ function showSetupWizard(message = null) {
     modalContent.insertAdjacentElement('afterend', messageDiv);
   } else {
     // Add welcome instructions
-    const existingMessage = settingsModal.querySelector('.setup-message');
-    if (existingMessage) {
-      existingMessage.remove();
+    const setupMessageElement = settingsModal.querySelector('.setup-message');
+    if (setupMessageElement && setupMessageElement.remove) {
+      setupMessageElement.remove();
     }
     
     const messageDiv = document.createElement('div');
@@ -582,9 +582,9 @@ function hideSettings() {
   modalContent.textContent = '設定';
   
   // Remove any setup messages
-  const existingMessage = settingsModal.querySelector('.setup-message');
-  if (existingMessage) {
-    existingMessage.remove();
+  const setupMessageElement = settingsModal.querySelector('.setup-message');
+  if (setupMessageElement && setupMessageElement.remove) {
+    setupMessageElement.remove();
   }
   
   // Reset cancel button text


### PR DESCRIPTION
## Summary
音声処理中に発生する `Cannot read properties of undefined (reading 'remove')` エラーを修正しました。

- 変数名の衝突を解決: `existingMessage` → `setupMessageElement`
- DOM操作の安全性を向上: 要素の存在確認とメソッドの有効性チェックを追加
- 3箇所の同様のパターンをすべて修正

## Test plan
- [ ] アプリケーションを起動して音声処理機能をテスト
- [ ] 設定画面の開閉動作を確認
- [ ] セットアップウィザード表示時のエラーがないことを確認
- [ ] DOM操作関連のランタイムエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)