### PR TITLE
🚨 fix: Obsidian Vault検証でのタイプエラーを修正 (closes #27)

### DIFF
--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -99,7 +99,7 @@ async function checkFirstTimeSetup() {
       // Validate Obsidian vault if path exists
       if (hasVaultPath) {
         await window.electronAPI.logInfo('Validating Obsidian vault path');
-        const validation = await window.electronAPI.validateObsidianVault(hasVaultPath);
+        const validation = await window.electronAPI.validateObsidianVault(settings.obsidianVaultPath);
         if (validation.success && !validation.validation.valid) {
           await window.electronAPI.logWarn('Obsidian vault validation failed', { 
             error: validation.validation.error 


### PR DESCRIPTION
## Summary
Obsidian Vault検証で発生する `vaultPath.trim is not a function` エラーを修正しました。

- boolean値 `hasVaultPath` の代わりに正しい文字列値 `settings.obsidianVaultPath` を使用
- 初期化時のVault検証が正常に動作するよう修正
- タイプエラーによる設定検証の失敗を解決

## Test plan
- [ ] アプリケーション初期化時にエラーが発生しないことを確認
- [ ] Obsidian Vault パスの検証が正常に動作することを確認
- [ ] 設定画面でのVault検証動作をテスト
- [ ] ログに `vaultPath.trim is not a function` エラーが出力されないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)