### PR TITLE
🤖 Dependabot自動マージ設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,16 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      separator: "/"
+    assignees:
+      - "nyasuto"
+    reviewers:
+      - "nyasuto"
+    labels:
+      - "dependencies"
+      - "javascript"
     
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -17,3 +27,13 @@ updates:
       day: "monday"
       time: "10:00"
       timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    pull-request-branch-name:
+      separator: "/"
+    assignees:
+      - "nyasuto"
+    reviewers:
+      - "nyasuto"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,21 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    
+    steps:
+    - name: Enable auto-merge for Dependabot PRs
+      run: gh pr merge --auto --squash "$PR_URL"
+      env:
+        PR_URL: ${{ github.event.pull_request.html_url }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要
Dependabotの管理を効率化するため、自動マージ機能を追加しました。

## 変更内容

### 1. Dependabot設定の強化
- **同時PR作成上限**: 5個 → 10個に増加
- **自動assignees/reviewers設定**: nyasutoを自動割り当て
- **ラベル自動付与**: dependencies, javascript/github-actions

### 2. 自動マージワークフロー追加
新しいDependabot PRが作成されたときに自動でauto-mergeを有効化

**ワークフロー動作:**
- Dependabot PRが作成されると自動実行
- `gh pr merge --auto --squash`でauto-mergeを有効化
- CIが通過すると自動的にsquash & mergeされる

## メリット
- ✅ 依存関係更新の管理工数削減
- ✅ より多くの依存関係を並行処理
- ✅ 手動でのauto-merge有効化が不要
- ✅ 一貫したマージ戦略（squash merge）

## 安全性
- CI/CDパイプラインでの品質チェックは維持
- レビュー必須設定がある場合は自動マージされない
- 問題があれば手動で介入可能

🤖 Generated with [Claude Code](https://claude.ai/code)